### PR TITLE
Fix map bugs

### DIFF
--- a/models/CV/object_detection/yolo/RKNN_python_demo/utils/coco_utils.py
+++ b/models/CV/object_detection/yolo/RKNN_python_demo/utils/coco_utils.py
@@ -33,8 +33,8 @@ def coco_eval_with_json(anno_json, pred_json):
     print('map  --> ', map)
     print('map50--> ', map50)
     print('map75--> ', eval.stats[2])
-    print('map85--> ', eval.stats[-2])
-    print('map95--> ', eval.stats[-1])
+    # print('map85--> ', eval.stats[-2])
+    # print('map95--> ', eval.stats[-1])
 
 class COCO_test_helper():
     def __init__(self, enable_letter_box = False) -> None:

--- a/models/CV/object_detection/yolo/RKNN_python_demo/yolo_map_test_rknn.py
+++ b/models/CV/object_detection/yolo/RKNN_python_demo/yolo_map_test_rknn.py
@@ -296,6 +296,11 @@ if __name__ == '__main__':
     if args.model not in SUPPORT_MODEL:
         print('ERROR: {} model type is not support.'.format(args.model))
         exit()
+    if args.coco_map_test:
+        print(' \n Warning!!!!!!!!!!!!!!!!!Test coco,be careful that OBJ_THRESH would be set to 0.001 ,img_show and img_save would be disabled \n')
+        OBJ_THRESH = 0.001
+        args.img_show = False
+        args.img_save = False
 
     # seting defualt hyperparam
     if args.model == 'yolox':


### PR DESCRIPTION
1. when caculate map,ogj_thresh should be less than 0.001,please refer to this link
https://github.com/ultralytics/yolov5/issues/7325
2. when using cocopytools api to calculate map,there are no map85 map95 by default.Unless change the source code of https://github.com/cocodataset/cocoapi/blob/master/PythonAPI/pycocotools/cocoeval.py